### PR TITLE
Fix code scanning alert no. 12: Arbitrary file access during archive extraction ("Zip Slip")

### DIFF
--- a/code/src/Attendee/Attendee.cs
+++ b/code/src/Attendee/Attendee.cs
@@ -9,7 +9,11 @@ namespace Attendees
     {
         public void WriteToDirectory(ZipArchiveEntry entry, string destDirectory)
         {
-            string destFileName = Path.Combine(destDirectory, entry.FullName);
+            string destFileName = Path.GetFullPath(Path.Combine(destDirectory, entry.FullName));
+            string fullDestDirPath = Path.GetFullPath(destDirectory + Path.DirectorySeparatorChar);
+            if (!destFileName.StartsWith(fullDestDirPath)) {
+                throw new InvalidOperationException("Entry is outside the target dir: " + destFileName);
+            }
             entry.ExtractToFile(destFileName);
         }
         


### PR DESCRIPTION
Fixes [https://github.com/kitavisteven/skills-secure-repository-supply-chain/security/code-scanning/12](https://github.com/kitavisteven/skills-secure-repository-supply-chain/security/code-scanning/12)

To fix the problem, we need to ensure that the output paths constructed from zip archive entries are validated to prevent writing files to unexpected locations. The steps to fix the issue are as follows:

1. Use `Path.Combine(destinationDirectory, entry.FullName)` to determine the raw output path.
2. Use `Path.GetFullPath(..)` on the raw output path to resolve any directory traversal elements.
3. Use `Path.GetFullPath(destinationDirectory + Path.DirectorySeparatorChar)` to determine the fully resolved path of the destination directory.
4. Validate that the resolved output path `StartsWith` the resolved destination directory, aborting if this is not true.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
